### PR TITLE
Add PSR-7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,10 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php":">5.5"
+        "php":">5.5",
+        "psr/http-message": "^1.0",
+        "guzzlehttp/psr7": "^1.4",
+        "http-interop/response-sender": "^1.0"
     },
     "autoload": {
       "psr-4": {

--- a/example/DummyController.php
+++ b/example/DummyController.php
@@ -29,16 +29,16 @@ class DummyController
 
     public function testWithParameter($param) {
 
-        return 'success '.$param;
+        sprintf('Calling with parameter %s',$param );
     }
 
-    public function testWithMoreParameter($param, $param2) {
+    public function testWithMoreParameter($id, $method) {
 
-        return 'success '.$param.':'.$param2;
+        return sprintf('Calling method %s from object#%d without parameter',$method, $id );
     }
 
-    public function testWithMoreParameterConstraint($param, $param2) {
+    public function testWithMoreParameterConstraint($id, $method, $param) {
 
-        return 'success constraint '.$param.':'.$param2;
+        return sprintf('Calling method %s from object#%d with parameter %s',$method, $id, $param );
     }
 }

--- a/example/index.php
+++ b/example/index.php
@@ -20,10 +20,10 @@ $router->get('/test/closure', function (){
 });
 
 // A pattern could match multiple HTTP verb, of course you can associate the same controller to all of them
-$router->get('/test', 'Noa\Router\Example\DummyController#testGet');
-$router->put('/test', 'Noa\Router\Example\DummyController#testPut');
-$router->post('/test', 'Noa\Router\Example\DummyController#testPost');
-$router->delete('/test', 'Noa\Router\Example\DummyController#testDelete');
+$router->get('/object', 'Noa\Router\Example\DummyController#testGet');
+$router->put('/object', 'Noa\Router\Example\DummyController#testPut');
+$router->post('/object', 'Noa\Router\Example\DummyController#testPost');
+$router->delete('/object', 'Noa\Router\Example\DummyController#testDelete');
 
 // You can parametrized by adding a semi-colon before route part
 // Thus all url like:
@@ -31,21 +31,22 @@ $router->delete('/test', 'Noa\Router\Example\DummyController#testDelete');
 //  - /test/12
 //  - /test/whatever
 // Will match this route
-$router->get('/test/:param', 'Noa\Router\Example\DummyController#testWithParameter');
+$router->get('/object/:param', 'Noa\Router\Example\DummyController#testWithParameter');
 
 // The same thing could be achieve with closure
-$router->get('/test/closure/:param', function ($param){
+$router->get('/object/closure/:param', function ($param){
     return 'success closure '.$param;
 });
 
 // Sometimes you want to match a route only if parameter match a specific regex, the with method allows to add constraints on parameter (route part beginning by ":")
 // Those two routes have the same verb and the same pattern but are considered as different routes because constraint on :param2
 // You can chain constraints as many as you want
-$router->get('/test/:param/param/:param2', 'Noa\Router\Example\DummyController#testWithMoreParameterConstraint')
-    ->with('param2', '[0-9]+')
-    ->with('param', '[a-z]+');
+$router->get('/object/:id/:method/:param', 'Noa\Router\Example\DummyController#testWithMoreParameterConstraint')
+    ->with('method', '[a-z]+')
+    ->with('param', '[0-9]+')
+    ->with('id', '[0-9]+');
 
-$router->get('/test/:param/param/:param2', 'Noa\Router\Example\DummyController#testWithMoreParameter');
+$router->get('/object/:id/:method', 'Noa\Router\Example\DummyController#testWithMoreParameter');
 
 try {
     echo $router->run();

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 This a simple PHP Router handling complex route patterns
 
 ## Description
-Provides a simple way to handle parametrized routes, with zero-dependency package.
+Provides a simple way to handle parametrized routes, compliant PSR-7.
 
 ## Installation
 
@@ -13,7 +13,7 @@ Provides a simple way to handle parametrized routes, with zero-dependency packag
 ## Usages
 ### How to create a Router
 
-Router handles routes, you must create a router before addind route.
+Router handles routes, you must create a router before adding route.
 
     <?php
     require_once vendor/autoload.php
@@ -22,33 +22,11 @@ Router handles routes, you must create a router before addind route.
     
     $router = new Router();
 
-#### Custom HTTP server vars
-
-In order to match route with HTTP request, the router must know which *$_SERVER* fields contain the request method and the request URI
-
-By default the router is configure like this:
-
-    array(
-        'method' => 'REQUEST_METHOD"
-        'url'    => 'REQUEST_URI'
-    );
-
-In case your HTTP Server don't follow this configuration, you can easily redefine this array with your custom fields
-
-    // Custom configuration
-    $configuration = array(
-        'method' => 'CUSTOM_REQUEST_METHOD"
-        'url'    => 'REQUEST_URI'
-    );
-    
-    // then create the router with custom configuration
-    $router = new Router($configuration);
-
 #### Get router instance
 
 You can also get a Router instance through a static call, with or without custom configuration 
 
-    $router = Router::getInstance($configuration);
+    $router = Router::getInstance();
     
 When you want to destroy this instance to create a new one, just
     
@@ -122,10 +100,10 @@ __Pattern matching following HTTP verb__
  
 A pattern could match multiple HTTP verb, of course you can associate the same controller to all of them.
 
-    $router->get('/test', 'Noa\Router\Example\DummyController#testGet');
-    $router->put('/test', 'Noa\Router\Example\DummyController#testPut');
-    $router->post('/test', 'Noa\Router\Example\DummyController#testPost');
-    $router->delete('/test', 'Noa\Router\Example\DummyController#testDelete');
+    $router->get('/object', 'Noa\Router\Example\DummyController#testGet');
+    $router->put('/object', 'Noa\Router\Example\DummyController#testPut');
+    $router->post('/object', 'Noa\Router\Example\DummyController#testPost');
+    $router->delete('/object', 'Noa\Router\Example\DummyController#testDelete');
 
 __Parametrized route__
  
@@ -138,11 +116,11 @@ Thus all url like:
 Will match this route:
 
 
-    $router->get('/test/:param', 'Noa\Router\Example\DummyController#testWithParameter');
+    $router->get('/object/:param', 'Noa\Router\Example\DummyController#testWithParameter');
         
 The same thing could be achieve with closure.
 
-    $router->get('/test/closure/:param', function ($param){
+    $router->get('/object/closure/:param', function ($param){
         return 'success closure '.$param;
     });
 
@@ -154,11 +132,12 @@ Those two routes have the same verb and the same pattern but are considered as d
 
 You can chain constraints as many as you want.
 
-    $router->get('/test/:param/param/:param2', 'Noa\Router\Example\DummyController#testWithMoreParameterConstraint')
-        ->with('param2', '[0-9]+')
-        ->with('param', '[a-z]+');
+    $router->get('/object/:id/:method/:param', 'Noa\Router\Example\DummyController#testWithMoreParameterConstraint')
+        ->with('method', '[a-z]+')
+        ->with('param', '[0-9]+')
+        ->with('id', '[0-9]+');
     
-    $router->get('/test/:param/param/:param2', 'Noa\Router\Example\DummyController#testWithMoreParameter');
+    $router->get('/object/:id/:method', 'Noa\Router\Example\DummyController#testWithMoreParameter');
 
 ### Launch route matcher
 
@@ -168,7 +147,7 @@ The return of *run* method will the controller return, feel free to do what you 
 
 In this example we only echoing this return.
 
-If non of the route matches, an exception is raised.
+If none of route matches, an exception is raised.
 
     try {
     

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -11,6 +11,7 @@ namespace Noa\Router\Test;
 use Noa\Router\RouterException;
 use PHPUnit\Framework\TestCase;
 use Noa\Router\Router;
+use Psr\Http\Message\ServerRequestInterface;
 
 
 class Test {
@@ -51,25 +52,6 @@ class RouterTest extends TestCase {
 
         $router2 = Router::getInstance();
         $this->assertEquals($router, $router2);
-    }
-
-    public function testGetInstanceWithCustomParameters() {
-
-        Router::destroy();
-
-        $configuration = array(
-            'url' => 'CUSTOM_REQUEST_URI'
-        );
-
-        $router = Router::getInstance($configuration);
-        $this->assertInstanceOf(Router::class, $router);
-
-        $router2 = Router::getInstance();
-        $this->assertEquals($router, $router2, 'Route still identical because instance isn\'t destroyed yet');
-
-        Router::destroy();
-        $router3 = Router::getInstance();
-        $this->assertNotEquals($router, $router3, 'Now the instance aren\'t the same');
     }
 
     /**
@@ -326,6 +308,20 @@ class RouterTest extends TestCase {
         $this->expectExceptionCode(RouterException::INVALID_CALLABLE);
         $router->run();
 
+    }
+
+    public function testGetRequest() {
+
+        $this->sendRequest('GET', '/api/test/get');
+
+        Router::destroy();
+        $router = Router::getInstance();
+
+        $request = $router->getRequest();
+
+        $this->assertInstanceOf(ServerRequestInterface::class, $request);
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals('/api/test/get', $request->getUri()->getPath());
     }
 
 }


### PR DESCRIPTION
This feature could have some breaking change, router configuration array is now obsolete. Beside the package has some dependancies:
- psr/http-message ( PSR-7 Interfaces )
- http-interop/response-sender ( Sender compliant PSR-7 )
- guzzlehttp/psr7 ( PSR-7 interfaces implementation )

The documentation and examples are already upadated.